### PR TITLE
docs:修正章节标题拼写错误

### DIFF
--- a/docs/Effective Python 3rd.md
+++ b/docs/Effective Python 3rd.md
@@ -1,4 +1,4 @@
 # Effective Python 3rd
 
 1. [Chapter 1: Pythonic Thinking](Chapter-1-Pythonic-Thinking/Chapter-1-Introduction.md)
-2. [Chapter 2: Strings and Slicing](Chapter-2-Strings-and-Slicing/Chapter-2-Instroduction.md)
+2. [Chapter 2: Strings and Slicing](Chapter-2-Strings-and-Slicing/Chapter-2-Introduction.md)


### PR DESCRIPTION
- 将 "Chapter-2-Instroduction.md" 修正为 "Chapter-2-Introduction.md"
- 修正了章节 2 引言部分的文件名拼写错误，确保了文件命名的一致性和正确性